### PR TITLE
Notify on remove

### DIFF
--- a/src/battleship-objects.js
+++ b/src/battleship-objects.js
@@ -258,6 +258,7 @@ class GameBoard extends Observable {
       this._ships.splice(shipIndex, 1);
       for (const { x, y } of ship.getPlacedCoordinates()) {
         delete this._shipGrid[this._indexAt(x, y)];
+        this.notifyChanged({ ship, x, y, action: 'remove' });
       }
       ship.remove();
       return true;


### PR DESCRIPTION
The Player object now notifies when removing a ship from the board. Like the placement notification, it fires for each affected cell and includes its coordinate pair in the event args.