### PR TITLE
Account for orientation when checking canPlace on click

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,9 +169,9 @@ const ShipBoardController = (function() {
       return;
     }
 
-    if (_player.canPlace(_currentShip, x, y)) {
+    const orientation = _isVertical ? 'vertical' : 'horizontal';
+    if (_player.canPlace(_currentShip, x, y, orientation)) {
       const shipToPlace = _currentShip;
-      const orientation = _isVertical ? 'vertical' : 'horizontal';
       _currentShip = null;
       _player.place(shipToPlace, x, y, orientation);
     } else {


### PR DESCRIPTION
This update fixes the bug where the UI was disallowing vertical ship placement on the right edge of the board and failing to check bounds on vertical placements on the bottom edge of the board. Now the canPlace call checks using the currently active orientation.