### PR TITLE
Transparent cells

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -81,20 +81,18 @@ section#player .board .cell.miss {
 /* Attacks on Opponent section */
 
 section#opponent {
-  --section-back-color: #dad1cc;
+  --grid-border-color: #8b8983;
   color: #323130;
-  background-color: var(--section-back-color, white);
+  background: #eeedec;
   padding: 10px 20px;
 }
 
 section#opponent .board {
-  background-color: #8b8983;
+  border: 2px solid var(--grid-border-color, gray);
   max-height: calc(100vh - 18rem);
   margin: auto;
-  padding: 2px;
 
   display: grid;
-  gap: 2px;
   /* Grid columns and rows are defined dynamically. */
 }
 
@@ -103,7 +101,7 @@ section#opponent .board.locked, section#opponent .board.locked .cell {
 }
 
 section#opponent .board .cell {
-  background-color: var(--section-back-color, white);
+  border: 1px solid var(--grid-border-color, gray);
   cursor: pointer;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -52,18 +52,17 @@ section#player #placement-action-bar {
 }
 
 section#player .board {
-  background-color: #193258;
+  --grid-border-color: #193258;
+  background-color: #124d9b;
+  border: 3px solid var(--grid-border-color);
   max-height: calc(100vh - 14rem);
   margin: auto;
-  padding: 5px;
-
   display: grid;
-  gap: 2px;
   /* Grid columns and rows are defined dynamically. */
 }
 
 section#player .board .cell {
-  background-color: #124d9b;
+  border: 1px solid var(--grid-border-color);
 }
 
 section#player .board .cell.ship {


### PR DESCRIPTION
This makes grid cell elements transparent and has grids use cell borders instead of gaps to achieve the appearance of grid lines. While these changes make no significant visual difference now, they will make it easier to use images to represent hits and misses.