### PR TITLE
Add Clear button to ship placement action bar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,11 @@ const ShipBoardController = (function() {
     _currentShip = ship;
   }
 
+  const releaseShip = function(ship) {
+    _isVertical = false;
+    _currentShip = ship;
+  }
+
   const getHeldShip = function() {
     return _currentShip;
   }
@@ -245,7 +250,15 @@ const ShipBoardController = (function() {
     }
   }
 
-  return { bindPlayer, holdShip, getHeldShip, rotate, lock, unlock };
+  return { 
+    bindPlayer, 
+    holdShip, 
+    getHeldShip,
+    releaseShip,
+    rotate, 
+    lock, 
+    unlock 
+  };
 }());
 
 //=============================================================================
@@ -329,6 +342,8 @@ const GameController = (function() {
     document.getElementById('placement-action-bar');
   const _placementRandomizeButton =
     document.getElementById('placement-randomize-button');
+  const _placementClearButton =
+    document.getElementById('placement-clear-button');
   const _placementDoneButton =
     document.getElementById('placement-done-button');
 
@@ -383,6 +398,12 @@ const GameController = (function() {
       startNextPlacementStep();
     });
 
+    // Set up Clear button.
+    _placementClearButton.addEventListener('click', function() {
+      player1.removeAllShips();
+      startNextPlacementStep();
+    })
+
     // Set up Done button.
     _placementDoneButton.addEventListener('click', function() {
       startAttackPhase();
@@ -402,6 +423,7 @@ const GameController = (function() {
   const startNextPlacementStep = function() {
     let remainingShips = player1.shipsToPlace;
     if (remainingShips.length == 0) {
+      ShipBoardController.releaseShip();
       setMessage("All your ships are placed. Click Done to start the attack phase.");
     } else {
       let nextShip = remainingShips[0];
@@ -453,7 +475,7 @@ const GameController = (function() {
   //-- Private event handling --
 
   const _onPlayerAction = function(eventArgs) {
-    if (eventArgs.action == 'place') {
+    if (eventArgs.action == 'place' || eventArgs.action == 'remove') {
       if (!ShipBoardController.getHeldShip()) {
         startNextPlacementStep();
       }

--- a/src/template.html
+++ b/src/template.html
@@ -21,6 +21,7 @@
       <h2><span id="player-name-possessive">Your</span> Ships</h2>
       <div id="placement-action-bar">
         <button id="placement-randomize-button">Randomize</button>
+        <button id="placement-clear-button">Clear</button>
         <button id="placement-done-button">Done</button>
       </div>
       <div id="player-board" class="board">


### PR DESCRIPTION
This update adds a Clear button to the ship placement action bar between the Randomize button and the Done button. When the Clear button is pressed, all ships are removed from the board, and the placement process starts over with the length-5 ship.